### PR TITLE
JB/Change wording on toast

### DIFF
--- a/yarn-project/zk-money/src/components/wallet_interaction_toast/sign_deposit_interaction.tsx
+++ b/yarn-project/zk-money/src/components/wallet_interaction_toast/sign_deposit_interaction.tsx
@@ -11,11 +11,12 @@ interface SignDepositInteractionProps {
 
 export function SignDepositInteraction(props: SignDepositInteractionProps) {
   const amount = useAmount(props.requiredFunds);
-  const prompt = `Approve transfer of ${amount?.format({ layer: 'L1' })}`;
+  const prompt = `Please transfer ${amount?.format({ layer: 'L1' })} to the Aztec contract`;
   return (
     <EnforcedRetryableSignInteractions
       onCancel={props.onCancel}
       flowState={props.flowState}
+      requestButtonLabel="Transfer"
       waitingText="Waiting for approval"
       prompt={prompt}
     />

--- a/yarn-project/zk-money/src/ui-components/components/signing_request/signing_request.tsx
+++ b/yarn-project/zk-money/src/ui-components/components/signing_request/signing_request.tsx
@@ -19,6 +19,7 @@ interface SigningRequestProps {
   waitingForSignature?: boolean;
   prompt?: string;
   toastMessage?: string;
+  requestButtonLabel?: string;
   requestButtonDisabled: boolean;
   onRequest?: () => void;
   onCancel?: () => void;
@@ -36,7 +37,11 @@ export function SigningRequest(props: SigningRequestProps) {
       )}
       <div className={style.interactions}>
         <ConnectButton accountStatus="address" showBalance={false} />
-        <Button onClick={props.onRequest} text={'Sign'} disabled={props.requestButtonDisabled} />
+        <Button
+          onClick={props.onRequest}
+          text={props.requestButtonLabel || 'Sign'}
+          disabled={props.requestButtonDisabled}
+        />
       </div>
     </div>
   );

--- a/yarn-project/zk-money/src/views/flow_interactions/enforced_retryable_sign_interactions.tsx
+++ b/yarn-project/zk-money/src/views/flow_interactions/enforced_retryable_sign_interactions.tsx
@@ -60,6 +60,7 @@ function getProps(flowState: EnforcedRetryableSignFlowState, waitingText: string
 export function EnforcedRetryableSignInteractions(props: {
   flowState: EnforcedRetryableSignFlowState;
   waitingText: string;
+  requestButtonLabel?: string;
   prompt?: string;
   messageToBeSigned?: string;
   onCancel?: () => void;
@@ -69,6 +70,7 @@ export function EnforcedRetryableSignInteractions(props: {
       messageToBeSigned={props.messageToBeSigned}
       prompt={props.prompt}
       onCancel={props.onCancel}
+      requestButtonLabel={props.requestButtonLabel}
       {...getProps(props.flowState, props.waitingText)}
     />
   );


### PR DESCRIPTION
# Description
New wording on this toast:
<img width="420" alt="Screenshot 2023-01-17 at 13 50 52" src="https://user-images.githubusercontent.com/11148144/212921880-57e444b9-1115-45f8-ad87-903d372a8af3.png">

Fixes bug that didn't allow showing the word "Retry" on this one:
<img width="626" alt="Screenshot 2023-01-17 at 13 55 24" src="https://user-images.githubusercontent.com/11148144/212921961-1481a7af-1f44-4676-bd97-9e7f982effab.png">


# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
