### PR TITLE
fix: set `showUnderlying = false`.

### DIFF
--- a/zk-money/src/alt-model/defi/card_configs/set_uniswap.ts
+++ b/zk-money/src/alt-model/defi/card_configs/set_uniswap.ts
@@ -62,7 +62,7 @@ export const SET_UNISWAP_CARD: CreateRecipeArgs = {
   },
   useEnterInteractionPredictionInfo: bindInteractionPredictionHook_expectedOutput({
     direction: 'enter',
-    showUnderlying: true,
+    showUnderlying: false,
     outputSelection: 'A',
   }),
   useExitInteractionPredictionInfo: bindInteractionPredictionHook_expectedOutput({


### PR DESCRIPTION
# Description

zk-money was trying to call getUnderlyingAmount on a bridge where this was not implemented. As an effect, the frontend crashed and went all blank when trying to enter Set prositions.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
