### PR TITLE
fix: Update compound APR computation.

### DIFF
--- a/zk-money/src/bridge-clients/client/compound/compound-bridge-data.ts
+++ b/zk-money/src/bridge-clients/client/compound/compound-bridge-data.ts
@@ -26,10 +26,12 @@ export class CompoundBridgeData extends ERC4626BridgeData {
     const cToken = ICERC20__factory.connect(cTokenAddress.toString(), this.ethersProvider);
 
     const supplyRatePerBlock = await cToken.supplyRatePerBlock();
-    return supplyRatePerBlock
-      .mul(blocksPerYear)
-      .div(10n ** 11n)
-      .toNumber() / 100000;
+    return (
+      supplyRatePerBlock
+        .mul(blocksPerYear)
+        .div(10n ** 11n)
+        .toNumber() / 100000
+    );
   }
 
   async getMarketSize(


### PR DESCRIPTION
# Description

Compound APR was read as if it was numbers and could handle fractions, e.g., APR < 1% would be rounded down to zero etc.
Updated to reduce precision such that the value can fit in number, then perform last reduction. 

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
