### PR TITLE
Specify Deposit Limit to be "Daily"

### DIFF
--- a/zk-money/src/alt-model/errors/error_utils.ts
+++ b/zk-money/src/alt-model/errors/error_utils.ts
@@ -19,7 +19,7 @@ const SNIPPETS_THAT_SHOULDNT_BE_SHOWN_TOP_LEVEL = [
   "Cannot read properties of undefined (reading 'isBatchingLegacy')",
   'MetaMask Message Signature: User denied message signature.',
   'MetaMask Tx Signature: User denied transaction signature.',
-  'Exceeded deposit limit',
+  'Exceeded daily deposit limit',
 ];
 
 export function shouldErrorBeShownAtTopLevel(error: unknown) {


### PR DESCRIPTION
# Description

A friend of mine was prompted with "Exceeded deposit limit" on zk.money and was terrified, as he misinterpreted it as some account / lifetime deposit limits.

This PR rewords the prompt as "Exceeded **daily** deposit limit".

Corresponding PR for [AztecProtocol/aztec2-internal](https://github.com/AztecProtocol/aztec2-internal/): https://github.com/AztecProtocol/aztec2-internal/pull/2350

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
