### PR TITLE
fix: Update curve slippage

### DIFF
--- a/zk-money/src/alt-model/defi/card_configs/lido.ts
+++ b/zk-money/src/alt-model/defi/card_configs/lido.ts
@@ -25,11 +25,11 @@ export const LIDO_CARD: CreateRecipeArgs = {
   },
   enterAuxDataResolver: {
     type: 'static',
-    value: 98n ** 17n, // Minimum acceptable amount of stEth per 1 eth
+    value: 98n * 10n ** 16n, // Minimum acceptable amount of stEth per 1 eth
   },
   exitAuxDataResolver: {
     type: 'static',
-    value: 95n * 10n ** 17n, // Minimum acceptable amount of eth per 1 stEth
+    value: 95n * 10n ** 16n, // Minimum acceptable amount of eth per 1 stEth
   },
   projectName: 'Lido',
   website: 'https://lido.fi/',


### PR DESCRIPTION
# Description

Closes #86. Updating minimum received amounts:
- eth -> steth: 0.98 steth pr eth
- steth -> eth: 0.95 eth pr steth.

We can probably move the bounds tighter on both sides. But this seem to be large enough for us not to need think much more about it and just let it chug along.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
