### PR TITLE
fix: remove element finance

### DIFF
--- a/zk-money/src/alt-model/defi/recipes.ts
+++ b/zk-money/src/alt-model/defi/recipes.ts
@@ -8,7 +8,6 @@ import {
 } from './types.js';
 import { RemoteAsset } from '../types.js';
 import { LIDO_CARD } from './card_configs/lido.js';
-import { ELEMENT_CARD, FLUSHED_ELEMENT_CARD } from './card_configs/element.js';
 import { YEARN_DAI_CARD, YEARN_ETH_CARD, YEARN_LUSD_CARD } from './card_configs/yearn.js';
 import { SEVEN_DAY_DCA_CARD_DAI_TO_ETH, SEVEN_DAY_DCA_CARD_ETH_TO_DAI } from './card_configs/seven_day_dca.js';
 import { EULER_DAI_CARD, EULER_ETH_CARD, EULER_WSTETH_CARD } from './card_configs/euler.js';
@@ -137,8 +136,6 @@ const CREATE_RECIPES_ARGS: CreateRecipeArgs[] = [
   YEARN_ETH_CARD,
   YEARN_DAI_CARD,
   LIDO_CARD,
-  FLUSHED_ELEMENT_CARD,
-  ELEMENT_CARD,
 ];
 
 export function createDefiRecipes(registrationsRepo: RegistrationsRepo) {


### PR DESCRIPTION
# Description

Removes element finanace from the defi page

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
