### PR TITLE
JB/Takes out yarn-project from config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -111,10 +111,10 @@
     "**/.yarn": true,
     "**/.pnp.*": true
   },
-  "typescript.tsdk": "yarn-project/.yarn/sdks/typescript/lib",
+  "typescript.tsdk": ".yarn/sdks/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
-  "eslint.nodePath": "yarn-project/.yarn/sdks",
-  "prettier.prettierPath": "yarn-project/.yarn/sdks/prettier/index.js",
+  "eslint.nodePath": ".yarn/sdks",
+  "prettier.prettierPath": ".yarn/sdks/prettier/index.js",
   "[cpp]": {
     "editor.defaultFormatter": "ms-vscode.cpptools"
   },


### PR DESCRIPTION
# Description

Updates .vsconfig paths to avoid issues with a wrong TS version being loaded up on VS Code.