### PR TITLE
Fix euler slippage

### DIFF
--- a/src/bridge-clients/client/euler/euler-redemption-bridge-data.ts
+++ b/src/bridge-clients/client/euler/euler-redemption-bridge-data.ts
@@ -9,7 +9,7 @@ export class EulerRedemptionBridgeData implements BridgeDataFieldGetters {
   protected constructor(protected ethersProvider: StaticJsonRpcProvider) {}
   // using 0.95 as minimums to account for large price fluctuations between dai/eth
   // in the time between user proof generation and inclusion on L1.
-  const MINIMUM_OUT = 95n * 10n ** 16n;
+  private MINIMUM_OUT = 95n * 10n ** 16n;
   minTokenOut = {
     0: MINIMUM_OUT, // ETH
     1: MINIMUM_OUT, // DAI


### PR DESCRIPTION
# Description

Changed `const` to `private` for the `MINIMUM_OUT` value on the euler redemption bridge.