### PR TITLE
fix: increased slippage due to failing swaps

### DIFF
--- a/src/bridge-clients/client/euler/euler-redemption-bridge-data.ts
+++ b/src/bridge-clients/client/euler/euler-redemption-bridge-data.ts
@@ -5,9 +5,9 @@ import { IERC4626__factory, IERC20Metadata__factory } from '../../typechain-type
 
 import { AuxDataConfig, AztecAsset, BridgeDataFieldGetters, SolidityType, UnderlyingAsset } from '../bridge-data.js';
 
-// using 0.95 as minimums to account for large price fluctuations between dai/eth
+// using 0.90 as minimums to account for large price fluctuations between dai/eth
 // in the time between user proof generation and inclusion on L1.
-const MINIMUM_OUT = 95n * 10n ** 16n;
+const MINIMUM_OUT = 90n * 10n ** 16n;
 
 export class EulerRedemptionBridgeData implements BridgeDataFieldGetters {
   protected constructor(protected ethersProvider: StaticJsonRpcProvider) {}


### PR DESCRIPTION
# Description

Exiting from Euler bridge currently [fails to execute](0x32296969Ef14EB0c6d29669C550D4a0449130230). Similarily to [what Lasse did in November](https://github.com/AztecProtocol/zk-money/commit/f77387a95100e66bb72fe6899011930fd9fb7b2a) I increased the allowed slippage by 5 more percents. Users might get sandwiched but I think it's not that important now given that Aztec Connect is about to die soon.

The slippage here is defined as how much of a wstETH a user gets for 1 ERC4626 vault share. The issue could be caused by low liquidity in the [balancer pool](https://app.balancer.fi/#/ethereum/pool/0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080) and/or price fluctuations between dai and eth (in case it takes a long time to mine the rollup block). 5 % change should be enough.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
